### PR TITLE
replace LDAPCustomMapping with LDAPUserSearch

### DIFF
--- a/coldfront_plugin_ru_ldap/backend.py
+++ b/coldfront_plugin_ru_ldap/backend.py
@@ -1,4 +1,4 @@
-from coldfront_plugin_ldap_custom_mapping.utils import LDAPCustomMapping
+from coldfront.plugins.ldap_user_search.utils import LDAPUserSearch
 from coldfront.core.utils.common import import_from_settings
 from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib.auth import get_user_model
@@ -20,7 +20,7 @@ class LDAPRemoteUserBackend(RemoteUserBackend):
             return None
         search_term = self.clean_username(remote_user)
         search_by = import_from_settings("RULDAP_SEARCH_BY", "username")
-        search = LDAPCustomMapping(search_term, search_by)
+        search = LDAPUserSearch(search_term, search_by)
         search_results = search.search_a_user(search_term, search_by)
         self.user_dict = search_results
         self.CONFIGURE_USER = import_from_settings("RULDAP_CONFIGURE_USER", configure_user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ldap3>=2.9.1
 python-ldap>=3.4.3
 coldfront
-git+https://github.com/cecilialau6776/ldap_custom_mapping


### PR DESCRIPTION
to show that ruldap still works, I set my user's `first_name`, `last_name`, and `email` to empty string, reauthenticate, and the attributes are populated again:

https://github.com/user-attachments/assets/95a10adb-cfc9-43ef-b696-b41ea295092e

~~I'm not 100% confident in this set because my system doesn't use SASL.~~